### PR TITLE
Fix JSON error

### DIFF
--- a/META.info
+++ b/META.info
@@ -6,7 +6,7 @@
         "provides" : {
             "Gumbo" : "lib/Gumbo.pm6",
 	    "Gumbo::Parser" : "lib/Gumbo/Parser.pm6",
-	    "Gumbo::Binding" : lib/Gumbo/Binding.pm6"
+	    "Gumbo::Binding" : "lib/Gumbo/Binding.pm6"
         },
         "depends" : [ "XML" , "HTML::Parser" ],
         "source-url" : "git://github.com/Skarsnik/perl6-gumbo.git"


### PR DESCRIPTION
Currently your module is missing from modules.perl6.org because the META file has a JSON error in it.

As a sidenote, I'd also suggest in the description instead of `a html parser` to use `an html parser`, since that's how I commonly hear it used ("an" instead of "a")
